### PR TITLE
Fix Flask version

### DIFF
--- a/language/requirements.txt
+++ b/language/requirements.txt
@@ -1,3 +1,3 @@
-Flask==1.0.2
+Flask==2.0.1
 google-cloud-language==1.1.1
 gunicorn==19.9.0


### PR DESCRIPTION
This app currently does not build. The error is `ImportError: cannot import name 'Markup' from 'jinja2'`.

Changing Flask version to 2.0.1 resolves the issue.